### PR TITLE
Remove place holder from chart

### DIFF
--- a/chart/springjavatemplate/Chart.yaml
+++ b/chart/springjavatemplate/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
-name: [PROJ_NAME_PLACEHOLDER]
+name: springJavaTemplate
 version: 1.0.0


### PR DESCRIPTION
Remove the project name place holder from the chart as the chart name needs to match the directory name.